### PR TITLE
Fix: Enable R key restart functionality at any time in Space Shooter

### DIFF
--- a/space-shooter.html
+++ b/space-shooter.html
@@ -714,9 +714,7 @@
                     e.preventDefault();
                     break;
                 case 'r':
-                    if (!gameActive) {
-                        restartGame();
-                    }
+                    restartGame();
                     break;
                 case 'p':
                 case 'escape':


### PR DESCRIPTION
- Removed condition that restricted R key to only work when game is over
- Players can now restart using R key during gameplay or after game over
- Fixes issue #12 where R key for restart was not working

Closes #12